### PR TITLE
ATEAM-1719: Add Support for Custom Headers in API Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ const authenticator: GenesysCloudClientAuthenticator = authenticatorFactory(clie
   environment: 'mypurecloud.com',
   persist: false,
   storageKey: 'gc_client_auth_data',
-  debugMode: false
+  debugMode: false,
+  customHeaders: {
+    'X-My-Header': 'value'
+  }
 });
 
 authenticator.loginImplicitGrant({
@@ -184,6 +187,12 @@ Params:
       * Defaults to: `false`
       */
       debugMode: boolean;
+
+      /**
+       * Custom headers to include in all API requests.
+       * Example: { 'X-My-Header': 'value' }
+       */
+      customHeaders?: Record<string, string>;
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ import { GenesysCloudClientAuthenticator, authenticatorFactory, IAuthData } from
 
 const clientId = 'Your Oauth ClientID';
 const authenticator: GenesysCloudClientAuthenticator = authenticatorFactory(clientId, {
-  /* these are the defaults */
   environment: 'mypurecloud.com',
   persist: false,
   storageKey: 'gc_client_auth_data',

--- a/src/lib/authenticator.ts
+++ b/src/lib/authenticator.ts
@@ -34,6 +34,7 @@ export class GenesysCloudClientAuthenticator {
   private hasLocalStorage: boolean;
   private authentications: { [authenitcation: string]: any };
   private timeout: number;
+  private customHeaders: Record<string, string> = {};
 
   /**
    * Construct a new Authenticator instance. It is recommended you use the `authenticatorFactory()`
@@ -54,6 +55,7 @@ export class GenesysCloudClientAuthenticator {
     }
 
     this.config = { ...config } as IAuthenticatorConfig;
+    this.customHeaders = config.customHeaders || {};
 
     this.setEnvironment(config.environment);
 
@@ -293,11 +295,17 @@ export class GenesysCloudClientAuthenticator {
    */
   callApi (path: string, httpMethod: 'get' | 'post', token?: string): superagent.Request {
     const uri = this.buildUrl(path);
-    return superagent[httpMethod](uri)
+    let req = superagent[httpMethod](uri)
       .type('application/json')
       .timeout(this.timeout)
-      .set('Authorization', `Bearer ${token || this.authData?.accessToken}`)
-      .send();
+      .set('Authorization', `Bearer ${token || this.authData?.accessToken}`);
+    // Add custom headers
+    if (this.customHeaders) {
+      Object.entries(this.customHeaders).forEach(([key, value]) => {
+        req = req.set(key, value);
+      });
+    }
+    return req.send();
   }
 
   /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,11 @@ export interface IAuthenticatorConfig {
    * Defaults to: `false`
    */
   debugMode: boolean;
+
+  /**
+   * Custom headers to include in all API requests.
+   */
+  customHeaders?: Record<string, string>;
 }
 
 export interface IAuthData {

--- a/test/unit/authenticator.test.ts
+++ b/test/unit/authenticator.test.ts
@@ -392,6 +392,31 @@ describe('GenesysCloudClientAuthenticator', () => {
     });
   });
 
+  describe('customHeaders', () => {
+    it('should include custom headers in all API requests', async () => {
+      const customHeaders = {
+        'X-Custom-Header': 'custom-value'
+      };
+      authenticator = new GenesysCloudClientAuthenticator(clientId, {
+        environment: 'mypurecloud.com',
+        persist: false,
+        storageKey: 'gc_client_auth_data',
+        debugMode: false,
+        customHeaders
+      });
+      const token = 'header-token';
+      const path = '/my/endpoint';
+      const endpoint = createNock()
+        .get(path)
+        .matchHeader('Authorization', `Bearer ${token}`)
+        .matchHeader('Content-Type', 'application/json')
+        .matchHeader('X-Custom-Header', 'custom-value')
+        .reply(200);
+      await authenticator.callApi(path, 'get', token);
+      endpoint.done();
+    });
+  });
+
   describe('_debug()', () => {
     let debugSpy: jest.SpyInstance;
     beforeEach(() => {


### PR DESCRIPTION
This PR introduces the ability for consumers of the `genesys-cloud-client-auth` library to inject custom HTTP headers (such as `Genesys-App`) into all API requests made by the authenticator, including internal requests like token validation.

### Details

- **Configuration Update:**  
  The `IAuthenticatorConfig` interface now supports an optional `customHeaders` property, allowing consumers to specify a map of headers to include with every API request.

- **Implementation:**  
  - The `GenesysCloudClientAuthenticator` class stores and applies these custom headers to all outgoing HTTP requests, ensuring they are present for both user-initiated and internal requests.
  - The `callApi` method was updated to merge and send the custom headers with each request.

- **Documentation:**  
  The README.md has been updated to document the new `customHeaders` option, including usage examples and configuration details.

### Motivation

This enhancement enables integrators to meet organizational or platform requirements for custom headers (e.g., for tracking, analytics, or compliance) without modifying the library’s internals.
